### PR TITLE
ci: add build verification + contribution scaffolding

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,67 @@
+name: Bug report
+description: clipi did something wrong, crashed, or behaved unexpectedly.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. The more specific you are, the faster it gets fixed.
+
+  - type: input
+    id: clipi-version
+    attributes:
+      label: clipi version
+      description: Visible in Settings → About, or via `defaults read /Applications/clipi.app/Contents/Info CFBundleShortVersionString`
+      placeholder: "0.1.1"
+    validations:
+      required: true
+
+  - type: input
+    id: macos-version
+    attributes:
+      label: macOS version
+      description: "Apple menu → About This Mac"
+      placeholder: "macOS 14.5 (23F79)"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: How was clipi installed?
+      options:
+        - Homebrew tap (brew install --cask navjots35/tap/clipi)
+        - DMG from GitHub Releases
+        - Built from source
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the bug. What did you do? What did clipi do? What did you expect to happen instead?
+      placeholder: |
+        1. Press ⌥⌘V to open clipi
+        2. Click the third item in the list
+        3. Expected: it pastes into the previous app
+           Actual: nothing happens / panel just closes / app crashes
+    validations:
+      required: true
+
+  - type: textarea
+    id: crash-log
+    attributes:
+      label: Crash log (if applicable)
+      description: |
+        If clipi crashed, attach the most recent crash report from `~/Library/Logs/DiagnosticReports/`.
+        Either paste the contents here (long is fine — we read them) or drag-drop the file.
+      render: shell
+
+  - type: checkboxes
+    id: ax-granted
+    attributes:
+      label: Accessibility permission
+      options:
+        - label: I've granted clipi Accessibility access in System Settings → Privacy & Security

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question / general discussion
+    url: https://github.com/navjots35/clipi/discussions
+    about: Use GitHub Discussions for questions about install, configuration, or general feedback that isn't a bug or feature request.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,31 @@
+name: Feature request
+description: Suggest a new behavior or capability for clipi.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filing: skim the [open enhancement issues](https://github.com/navjots35/clipi/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement) to make sure this isn't already discussed. clipi tries to stay small and keyboard-first; features that pull it toward "do everything" are likely to be politely declined.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Describe the actual workflow / friction. Not the proposed solution — that comes next.
+      placeholder: |
+        I copy hex color codes constantly while designing. When I summon clipi, color items
+        all look identical because the title is just "#1A2B3C" with no preview swatch.
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: What's your proposed solution?
+      description: Optional. If you have a specific idea, share it. If not, leave blank — sometimes the right design comes from the discussion.
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you've considered
+      description: Other apps that solve this, or workarounds you currently use.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+<!--
+Thanks for sending a PR! A few asks before you submit:
+- Target the `develop` branch (PRs to `main` are auto-rejected by branch rules).
+- Run `./scripts/build.sh` locally and confirm the app launches.
+- Keep changes tightly scoped — split unrelated cleanup into separate PRs.
+-->
+
+## What does this change?
+
+<!-- One paragraph. What's different now? Why? -->
+
+## How was it tested?
+
+<!--
+Manual testing, automated tests, or both. For UI changes, mention the macOS
+version you tested on and what the panel/window looked like before vs. after.
+-->
+
+- [ ] Built locally with `./scripts/build.sh`
+- [ ] Smoke-tested ⌥⌘V → pick row → paste flow
+- [ ] (If touching settings) Smoke-tested Settings open + close
+- [ ] (If touching watcher / privacy) Verified the relevant rule still excludes captures
+
+## Related issues
+
+<!-- Reference any open issues this addresses (e.g. "Fixes #42") -->
+
+## Screenshots / GIFs (UI changes only)
+
+<!-- Drop them in here. Before / after side-by-side preferred. -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  # GitHub Actions versions in .github/workflows/*.yml — keeps actions/checkout
+  # and friends pinned to current stable releases without manual chasing.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+      - "ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+name: CI
+
+# Runs on every push to main/develop and on every PR targeting them.
+# Build verification only — no signing identity, no notarization. The release
+# pipeline (scripts/release.sh) is invoked manually with the maintainer's
+# Developer ID cert in their keychain; CI just confirms `./scripts/build.sh`
+# produces a well-formed bundle on a clean macOS runner.
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+# Cancel an in-flight CI run when a new commit is pushed to the same PR/branch.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build · ${{ matrix.os }} · ${{ matrix.opt }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-14, macos-latest]
+        opt: [Onone, O]   # debug-grade and release-grade
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Toolchain versions
+        run: |
+          echo "macOS: $(sw_vers -productVersion)"
+          echo "Xcode: $(xcodebuild -version | head -1)"
+          echo "Swift: $(swift --version | head -1)"
+          echo "SDK: $(xcrun --sdk macosx --show-sdk-version)"
+
+      - name: Build (ad-hoc signed)
+        run: OPT_FLAG=-${{ matrix.opt }} ./scripts/build.sh
+
+      - name: Verify bundle structure
+        run: |
+          set -euo pipefail
+          test -x build/clipi.app/Contents/MacOS/clipi
+          test -f build/clipi.app/Contents/Info.plist
+          test -f build/clipi.app/Contents/Resources/clipi.icns
+          test -f build/clipi.app/Contents/PkgInfo
+
+      - name: Verify code signature
+        run: codesign --verify --deep --strict --verbose=2 build/clipi.app
+
+      - name: Validate Info.plist keys
+        run: |
+          set -euo pipefail
+          PB=/usr/libexec/PlistBuddy
+          PLIST=build/clipi.app/Contents/Info.plist
+          # Sanity-check that required Info.plist keys exist; PlistBuddy exits
+          # non-zero if any key is missing, which fails the step.
+          $PB -c "Print :CFBundleIdentifier" $PLIST
+          $PB -c "Print :CFBundleVersion" $PLIST
+          $PB -c "Print :CFBundleShortVersionString" $PLIST
+          $PB -c "Print :NSAccessibilityUsageDescription" $PLIST
+
+      - name: Binary architecture report
+        run: lipo -info build/clipi.app/Contents/MacOS/clipi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing to clipi
+
+Thanks for your interest in contributing. clipi is small on purpose — the goal is a fast, opinionated, keyboard-first clipboard manager, not a Swiss-army-knife app — so the bar for new behavior is "does this make the keyboard flow tighter?"
+
+## Branch model
+
+- **`main`** — production. Protected. Only release-ready code, only merged via PR.
+- **`develop`** — integration. **All PRs target this branch.** When `develop` is stable, a release PR brings it into `main`.
+- **Topic branches** — your changes live here, branched off `develop`, named like `fix/settings-close-recursion` or `feat/sparkle-updater`.
+
+## Getting set up
+
+Requirements: macOS 13+, Xcode 15+ (for the Swift 6 toolchain that ships with it).
+
+```sh
+git clone https://github.com/navjots35/clipi.git
+cd clipi
+git checkout develop
+./scripts/build.sh        # ad-hoc signed dev build at build/clipi.app
+open build/clipi.app
+```
+
+Grant Accessibility on first launch, then ⌥⌘V should summon the panel.
+
+## Making a change
+
+1. Branch from `develop`: `git switch -c fix/whatever develop`
+2. Make your change. Try to keep PRs single-purpose — easier to review, easier to revert.
+3. Run `./scripts/build.sh` and smoke-test the affected flow.
+4. Commit with a descriptive message — first line is the subject (≤72 chars), body is the *why*.
+5. Push and open a PR against `develop`. CI will build on macOS 14 + macOS-latest under both `-Onone` and `-O` to catch optimization-only regressions.
+
+## Code conventions
+
+- **Swift style** — match the existing files. We follow the standard Swift API design guidelines plus a few project-specific habits documented in the source via `// MARK:` headers and inline comments where the *why* is non-obvious.
+- **Comments** — for the *why*, not the *what*. If a method needs a comment to explain what it does, the method name is wrong.
+- **No new third-party dependencies** without discussion — clipi is intentionally vendor-free (no SPM packages so far) and we'd rather a 50-line implementation than a 50-MB framework. If you genuinely need one, open an issue first.
+- **Error handling** — fail open for capture (a missing pasteboard type → skip that copy, don't crash). Fail closed for security (any ambiguity about whether something is a password → don't capture).
+
+## What kinds of changes are most welcome
+
+- Bug fixes (with a clear reproduction)
+- Performance improvements with a measurement
+- Privacy / security hardening — additional secure-field detection, password manager bundle IDs, etc.
+- Accessibility improvements
+- Documentation, README polish
+- New per-app rule defaults that catch more sensitive contexts
+
+## What's likely to get pushback
+
+- Major UI changes that move clipi away from the design language documented in `Clipi.html`
+- Features that pull clipi into "do everything" territory (snippet expansion, cloud sync, AI integrations) — not because they're bad ideas, but because they'd be better as a separate app or fork
+- Adding telemetry / analytics of any kind
+- Changes that introduce a third-party SPM dependency without an issue discussion first
+
+## Reporting bugs
+
+Use the [bug report template](https://github.com/navjots35/clipi/issues/new?template=bug_report.yml). The more specific the repro, the faster the fix.
+
+If you find a security issue (something that could capture data clipi shouldn't), please email rather than filing a public issue — see the SECURITY.md (TODO) once it exists, or just include "security:" in your bug-report subject line.
+
+## License
+
+By contributing, you agree your code will be released under the same MIT license as the rest of the project.


### PR DESCRIPTION
- .github/workflows/ci.yml: build on macos-14 and macos-latest under both -Onone and -O. Verifies bundle structure, code signature, and required Info.plist keys. Cancels in-flight runs on new pushes.
- .github/PULL_REQUEST_TEMPLATE.md: prompts contributors to target develop, document testing, and link related issues.
- .github/ISSUE_TEMPLATE/{bug_report,feature_request,config}.yml: structured issue forms; blank issues disabled in favor of templates.
- .github/dependabot.yml: monthly bumps for github-actions versions.
- CONTRIBUTING.md: branch model, dev setup, scope guidance, what changes are welcome vs. likely to get pushback.